### PR TITLE
fix : user의 조회,삭제 기능 수정

### DIFF
--- a/src/main/java/com/example/newsfeed/dto/user/ReadUserResponseDto.java
+++ b/src/main/java/com/example/newsfeed/dto/user/ReadUserResponseDto.java
@@ -4,6 +4,8 @@ import com.example.newsfeed.entity.User;
 import lombok.Getter;
 
 import java.time.LocalDate;
+import java.time.LocalDateTime;
+
 @Getter
 public class ReadUserResponseDto {
     private Long userId;
@@ -11,13 +13,17 @@ public class ReadUserResponseDto {
     private String email;
     private LocalDate created_date;
     private LocalDate updated_date;
+    private LocalDateTime leave_date;
+    private String userStatus;
 
-    public ReadUserResponseDto(Long userId, String username, String email, LocalDate created_date, LocalDate updated_date) {
+    public ReadUserResponseDto(Long userId, String username, String email, LocalDate created_date, LocalDate updated_date,LocalDateTime leave_date,String userStatus) {
         this.userId = userId;
         this.username = username;
         this.email = email;
         this.created_date = created_date;
         this.updated_date = updated_date;
+        this.leave_date=leave_date;
+        this.userStatus=userStatus;
     }
     public ReadUserResponseDto(User user) {
         this.userId = user.getUserId();
@@ -25,10 +31,12 @@ public class ReadUserResponseDto {
         this.email = user.getEmail();
         this.created_date = user.getCreatedDate();
         this.updated_date = user.getUpdatedDate();
+        this.leave_date=user.getLeave_date();
+        this.userStatus=user.getUserStatus();
 
     }
 
     public static ReadUserResponseDto toUserResponseDto(User user) {
-        return new ReadUserResponseDto(user.getUserId(), user.getUsername(), user.getEmail(), user.getCreatedDate(), user.getUpdatedDate());
+        return new ReadUserResponseDto(user.getUserId(), user.getUsername(), user.getEmail(), user.getCreatedDate(), user.getUpdatedDate(),user.getLeave_date(), user.getUserStatus());
     }
 }

--- a/src/main/java/com/example/newsfeed/entity/User.java
+++ b/src/main/java/com/example/newsfeed/entity/User.java
@@ -4,7 +4,10 @@ import com.example.newsfeed.dto.user.SignupUserRequestDto;
 import jakarta.persistence.*;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import lombok.Setter;
 
+import java.time.LocalDate;
+import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -20,6 +23,11 @@ public class User extends BaseEntity {
     private String username; // 유저 이름
     private String email; //이메일
     private String password; //패스워드
+    @Setter
+    private LocalDateTime leave_date; // 탈퇴날짜
+    @Column(name = "user_status")
+    @Setter
+    private String userStatus="Y"; // 회원상태
     public User(SignupUserRequestDto signupUserRequestDto) {
         this.username=signupUserRequestDto.getUsername();
         this.email=signupUserRequestDto.getEmail();

--- a/src/main/java/com/example/newsfeed/service/UserService.java
+++ b/src/main/java/com/example/newsfeed/service/UserService.java
@@ -9,6 +9,8 @@ import jakarta.servlet.http.HttpSession;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
+import java.time.LocalDate;
+import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Optional;
 
@@ -74,6 +76,8 @@ public class UserService {
                 session.invalidate();
             }
         }
-        userRepository.delete(user);
+        user.setUserStatus("N");
+        user.setLeave_date(LocalDateTime.now());
+        userRepository.save(user);
     }
 }


### PR DESCRIPTION
user 엔티티에 탈퇴일시,현재 가입상태를 나타내는 필드를 추가하고 조회시 가입상태와 탈퇴일시를 알 수 있게 requestdto 수정 탈퇴시 영구적으로 삭제되지 않고 상태만 비활성화 상태로 나타내도록 수정